### PR TITLE
Vorschlag: counters für traffic

### DIFF
--- a/checks/fastd
+++ b/checks/fastd
@@ -35,6 +35,8 @@
 #wiesbaden rx_bytes 1942991369
 #wiesbaden rx_packets 14728796
 
+import datetime
+
 factory_settings["fastd_stats_default_levels"] = {
    'peers_online':  (100,  150),
 }
@@ -130,17 +132,26 @@ def check_fastd_traffic(item, params, info):
     state = 0
     infos   = []
     perfdata = []
+    this_time = time.time()
+    wrapped = False
 
     for unit, field, descr in [
-                  ('',       'tx_bytes',          'Bytes out',          ),
-                  ('',       'tx_packets',        'Packets out'         ),
-                  ('',       'rx_bytes',          'Bytes in',           ),
-                  ('',       'rx_packets',        'Packets in',         )]:
+                  ('bps',       'tx_bytes',          'Bytes per sec out',          ),
+                  ('pps',       'tx_packets',        'Packets per sec out'         ),
+                  ('bps',       'rx_bytes',          'Bytes per sec in',           ),
+                  ('pps',       'rx_packets',        'Packets per sec in',         )]:
         if field in instance:
-            value = instance[field]
-            infos.append("%s: %d%s" % (descr, value, unit))
-            perfdata.append((field, value))
+            abs_value = instance[field]
+            rate = 0
+            try:
+                timediff,rate = get_counter("fastd.traffic.%s.%s" % (item,field), this_time, abs_value)
+            except MKCounterWrapped:
+                wrapped = True
+            infos.append("%s: %d%s" % (descr, rate, unit))
+            perfdata.append((field, rate))
 
+    if wrapped:
+        raise MKCounterWrapped("Counter wrap")
     return state, ", ".join(infos), perfdata
 
 check_info["fastd.stats"] = {

--- a/checks/ubnt_stations
+++ b/checks/ubnt_stations
@@ -73,14 +73,15 @@ def ret_ubnt_stations(name, snr, signal, noise, dist, txcap, rxcap, connt, txrat
     if noise_copy == None:
         noise_copy = -95
     perfdata = [ 
-                ("SNR /dBm", snr, warn, crit, 0),
-                ("rx capacity /Mbps", rxcap, None, None, 0),
-                ("tx capacity /Mbps", txcap, None, None, 0),
-                ("in /bps", rxrate, None, None, 0),
-                ("out /bps", txrate, None, None, 0),
-                ("connect time /days", connt, None, None, 0),
-                ("signal /dBm", signal, noise_copy+warn, noise_copy+crit, 0),
-                ("noise /dBm", noise, None, None, 0),
+                ("SNR /dBm", snr, warn, crit),
+                ("rx capacity /Mbps", rxcap),
+                ("tx capacity /Mbps", txcap),
+                ("in /bps", rxrate),
+                ("out /bps", txrate),
+                ("connect time /days", connt),
+                #("signal /dBm", signal, noise_copy+warn, noise_copy+crit, 0),
+                ("signal /dBm", signal, None, None, -100, -50),
+                ("noise /dBm", noise, None, None),
                ]
     if noise == None:
         infotext = " - SNR: approx. %d dB, S: %d dBm, capacity RX/TX: %d/%d Mbps, MAC: %s" % \
@@ -98,7 +99,7 @@ def ret_ubnt_stations(name, snr, signal, noise, dist, txcap, rxcap, connt, txrat
 def check_ubnt_stations(item, params, info):
     warn, crit = params
     info_id, info_41112, info_14988 = info
-    maybe_old_fw = (info_id[0] == ".1.3.6.1.4.1.10002.1") # old fw AND new 7.1.4 announce this
+    maybe_old_fw = (info_id[0][0] == ".1.3.6.1.4.1.10002.1") # old fw AND new 7.1.4 announce this
     for line in info_41112:
         mac = convertOidToMac(line[0])
         if mac == item:
@@ -114,7 +115,7 @@ def check_ubnt_stations(item, params, info):
 check_info["ubnt_stations"] = {
     "check_function":		check_ubnt_stations,
     "inventory_function":	inventory_ubnt_stations,
-    "service_description":	"Station %s",
+    "service_description":	"STA %s",
     "has_perfdata":		True,
     "snmp_info":		[
         ( ".1.3.6.1.2.1.1", [ "2.0", "9.1.2.4" ] ),


### PR DESCRIPTION
Vorschlag: Anstelle wachsenden Absolutwerten counter (also Ausgabe von units ore sec) für den traffic-Teil verwenden.
mangels Möglichkeit noch ungetestet ...
